### PR TITLE
Migrated container to custom build-dotnet image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,17 @@ on:
 env:
   OPENTAP_ANSI_COLORS: true
   OPENTAP_NO_UPDATE_CHECK: true
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]
-    container: mcr.microsoft.com/dotnet/sdk:8.0
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     env:
       KS8500_REPO_TOKEN: ${{ secrets.KS8500_REPO_TOKEN }}
       TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS_INTERNAL }}
@@ -56,7 +61,7 @@ jobs:
     runs-on:
       group: OpenTAP-SpokeVPC
       labels:  [Linux, X64]
-    container: mcr.microsoft.com/dotnet/sdk:8.0
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
     needs: build
     steps:
     - name: Download binaries


### PR DESCRIPTION
Migrated runners to self hosted in order for fixing the compliance on https://github.com/opentap/KS8400/issues/1068